### PR TITLE
Refactor the decision trees to use Numpy instead of Pandas

### DIFF
--- a/src/class_reg_decision_tree.py
+++ b/src/class_reg_decision_tree.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 import random
 from tqdm import tqdm
 
+
 def gini_impurity(y: np.ndarray) -> float:
     """Optimized gini using numpy arrays instead of pandas"""
     if len(y) == 0:
@@ -18,31 +19,33 @@ def gini_gain(y: np.ndarray, left_mask: np.ndarray, right_mask: np.ndarray) -> f
     """Optimized gini gain using numpy arrays"""
     left_count = np.sum(left_mask)
     right_count = np.sum(right_mask)
-    
+
     if left_count == 0 or right_count == 0:
         return -np.inf
-    
+
     total_count = len(y)
     left_impurity = gini_impurity(y[left_mask])
     right_impurity = gini_impurity(y[right_mask])
-    
-    weighted_impurity = (left_count * left_impurity + right_count * right_impurity) / total_count
+
+    weighted_impurity = (
+        left_count * left_impurity + right_count * right_impurity
+    ) / total_count
     return gini_impurity(y) - weighted_impurity
 
 
 def get_splits_continuous(col: np.ndarray, num_splits: int = 5):
     """Optimized continuous splits using numpy"""
     unique_vals = np.unique(col[~np.isnan(col)])  # Remove NaNs first
-    
+
     if len(unique_vals) <= 1:
         return
-    
+
     if len(unique_vals) <= num_splits:
         thresholds = (unique_vals[:-1] + unique_vals[1:]) / 2
     else:
         percentiles = np.linspace(0, 100, num_splits + 2)[1:-1]
         thresholds = np.unique(np.percentile(unique_vals, percentiles))
-    
+
     for t in thresholds:
         left_mask = col <= t
         yield float(t), left_mask, ~left_mask
@@ -54,52 +57,59 @@ def get_random_splits_categorical(col: np.ndarray, num_random: int = 5):
     mask = ~pd.isna(col)
     if not mask.any():
         return
-        
+
     unique_vals = np.unique(col[mask])
     n = len(unique_vals)
-    
+
     if n <= 1:
         return
-    
+
     for _ in range(num_random):
         k = random.randint(1, n - 1)
         subset = set(np.random.choice(unique_vals, k, replace=False))
         left_mask = np.isin(col, list(subset))
         right_mask = ~left_mask
-        
+
         if not left_mask.any() or not right_mask.any():
             continue
-            
+
         yield subset, left_mask, right_mask
 
 
-def gini_best_splits(X: np.ndarray, y: np.ndarray, feature_names: list, features_to_explore: list | None = None):
+def gini_best_splits(
+    X: np.ndarray,
+    y: np.ndarray,
+    feature_names: list,
+    features_to_explore: list | None = None,
+):
     """Optimized best splits using numpy arrays"""
     best_splits = [(None, None, -np.inf)]
-    
+
     if features_to_explore is None:
         features_to_explore = list(range(len(feature_names)))
     else:
         # Convert feature names to indices
-        features_to_explore = [feature_names.index(f) for f in features_to_explore if f in feature_names]
-    
+        features_to_explore = [
+            feature_names.index(f) for f in features_to_explore if f in feature_names
+        ]
+
     for col_idx in features_to_explore:
         x_col = X[:, col_idx]
         best_gain = -np.inf
         best_condition = None
-        
+
         # Handle regular splits
         if np.issubdtype(x_col.dtype, np.number):
             splitter = get_splits_continuous(x_col)
         else:
             splitter = get_random_splits_categorical(x_col)
-        
+
         for condition, left_mask, right_mask in splitter:
             gain = gini_gain(y, left_mask, right_mask)
             if gain > best_gain:
                 best_gain = gain
                 best_condition = condition
-        
+
         # Handle null split
         null_mask = pd.isna(x_col)
         non_null_mask = ~null_mask
@@ -108,12 +118,12 @@ def gini_best_splits(X: np.ndarray, y: np.ndarray, feature_names: list, features
             if null_gain > best_gain:
                 best_gain = null_gain
                 best_condition = "__NULL__"
-        
+
         if best_gain == best_splits[0][2]:
             best_splits.append((feature_names[col_idx], best_condition, best_gain))
         elif best_gain > best_splits[0][2]:
             best_splits = [(feature_names[col_idx], best_condition, best_gain)]
-    
+
     return best_splits
 
 
@@ -128,7 +138,7 @@ class CartNode:
     def split(self, X: np.ndarray, col_idx: int) -> tuple[np.ndarray, np.ndarray]:
         """Optimized split using numpy arrays"""
         x_col = X[:, col_idx]
-        
+
         if isinstance(self.condition, set):
             left_mask = np.isin(x_col, list(self.condition))
         elif isinstance(self.condition, float):
@@ -137,64 +147,72 @@ class CartNode:
             left_mask = pd.isna(x_col)
         else:
             raise ValueError("Condition is not valid!")
-            
+
         return left_mask, ~left_mask
 
 
 class RandCart:
     def __init__(
-            self, 
-            X_train: pd.DataFrame, 
-            y_train: pd.Series, 
-            max_features_to_explore: int = 5,
-            max_depth: int = 10,
-            min_samples_split: int = 5,
-            use_progress_bar: bool = False
-        ):
+        self,
+        X_train: pd.DataFrame,
+        y_train: pd.Series,
+        max_features_to_explore: int = 5,
+        max_depth: int = 10,
+        min_samples_split: int = 5,
+        use_progress_bar: bool = False,
+    ):
         # Convert to numpy arrays for faster computation
         self.X_train_np = X_train.values
         self.y_train_np = y_train.values
         self.feature_names = list(X_train.columns)
         self.class_names = [str(c) for c in y_train.unique()]
-        
-        self.max_features_to_explore = min(max_features_to_explore, len(X_train.columns)//2)
+
+        self.max_features_to_explore = min(
+            max_features_to_explore, len(X_train.columns) // 2
+        )
         self.max_depth = max_depth
         self.min_samples_split = min_samples_split
-        self.root = CartNode(None, None, None, None, self.get_probs_as_dict(y_train.values))
+        self.root = CartNode(
+            None, None, None, None, self.get_probs_as_dict(y_train.values)
+        )
         self.use_progress_bar = use_progress_bar
 
     def get_probs_as_dict(self, y: np.ndarray):
         """Optimized probability calculation using numpy"""
         if len(y) == 0:
             return {name: 0.0 for name in self.class_names}
-        
+
         unique_vals, counts = np.unique(y, return_counts=True)
-        prob_dict = {str(val): count/len(y) for val, count in zip(unique_vals, counts)}
-        
+        prob_dict = {
+            str(val): count / len(y) for val, count in zip(unique_vals, counts)
+        }
+
         # Fill in missing classes with 0 probability
         for class_name in self.class_names:
             if class_name not in prob_dict:
                 prob_dict[class_name] = 0.0
-                
+
         return prob_dict
 
     def predict(self, X: pd.DataFrame):
         """Optimized prediction using numpy arrays"""
-        assert list(X.columns) == self.feature_names, "Inference data does not have the same columns as train data"
-        
+        assert (
+            list(X.columns) == self.feature_names
+        ), "Inference data does not have the same columns as train data"
+
         X_np = X.values
         n_samples = len(X)
         n_classes = len(self.class_names)
-        
+
         # Pre-allocate result array
         predictions = np.zeros((n_samples, n_classes))
         sample_indices = np.arange(n_samples)
-        
+
         nodes_to_visit = [(self.root, sample_indices)]
-        
+
         while nodes_to_visit:
             node, indices = nodes_to_visit.pop()
-            
+
             if node.split_column is None:
                 # Leaf node - assign probabilities
                 for i, class_name in enumerate(self.class_names):
@@ -203,15 +221,15 @@ class RandCart:
                 # Split node
                 col_idx = self.feature_names.index(node.split_column)
                 left_mask, right_mask = node.split(X_np[indices], col_idx)
-                
+
                 left_indices = indices[left_mask]
                 right_indices = indices[right_mask]
-                
+
                 if len(left_indices) > 0:
                     nodes_to_visit.append((node.left, left_indices))
                 if len(right_indices) > 0:
                     nodes_to_visit.append((node.right, right_indices))
-        
+
         return pd.DataFrame(predictions, columns=self.class_names, index=X.index)
 
     def fit(self):
@@ -221,22 +239,28 @@ class RandCart:
 
         def should_stop(y, best_gain, depth):
             return (
-                len(y) < self.min_samples_split or
-                gini_impurity(y) == 0 or
-                best_gain <= 0 or
-                depth >= self.max_depth
+                len(y) < self.min_samples_split
+                or gini_impurity(y) == 0
+                or best_gain <= 0
+                or depth >= self.max_depth
             )
-        
+
         def expand_tree(node: CartNode, indices: np.ndarray, depth: int):
             X_temp = self.X_train_np[indices]
             y_temp = self.y_train_np[indices]
-            
+
             # Randomly select features to explore
-            n_features_to_try = min(self.max_features_to_explore, len(self.feature_names))
-            random_feature_indices = np.random.choice(len(self.feature_names), n_features_to_try, replace=False)
+            n_features_to_try = min(
+                self.max_features_to_explore, len(self.feature_names)
+            )
+            random_feature_indices = np.random.choice(
+                len(self.feature_names), n_features_to_try, replace=False
+            )
             random_features = [self.feature_names[i] for i in random_feature_indices]
-            
-            best_splits = gini_best_splits(X_temp, y_temp, self.feature_names, random_features)
+
+            best_splits = gini_best_splits(
+                X_temp, y_temp, self.feature_names, random_features
+            )
 
             if should_stop(y_temp, best_splits[0][2], depth):
                 if self.use_progress_bar:
@@ -256,16 +280,18 @@ class RandCart:
             left_indices = indices[left_mask]
             left_y = y_temp[left_mask]
             node.left = CartNode(None, None, None, None, self.get_probs_as_dict(left_y))
-            expand_tree(node.left, left_indices, depth+1)
+            expand_tree(node.left, left_indices, depth + 1)
 
             right_indices = indices[right_mask]
             right_y = y_temp[right_mask]
-            node.right = CartNode(None, None, None, None, self.get_probs_as_dict(right_y))
-            expand_tree(node.right, right_indices, depth+1)
+            node.right = CartNode(
+                None, None, None, None, self.get_probs_as_dict(right_y)
+            )
+            expand_tree(node.right, right_indices, depth + 1)
 
         initial_indices = np.arange(len(self.y_train_np))
         expand_tree(self.root, initial_indices, 0)
-        
+
         if self.use_progress_bar:
             pbar.close()
 
@@ -273,7 +299,9 @@ class RandCart:
         def print_node(node: CartNode, prefix: str = "", is_left: bool = True):
             connector = "├── " if is_left else "└── "
             if node.split_column is None:
-                probs = ", ".join(f"{k}: {v:.2f}" for k, v in node.probabilities.items())
+                probs = ", ".join(
+                    f"{k}: {v:.2f}" for k, v in node.probabilities.items()
+                )
                 print(f"{prefix}{connector}Leaf: [{probs}]")
             else:
                 if isinstance(node.condition, set):

--- a/src/class_reg_decision_tree.py
+++ b/src/class_reg_decision_tree.py
@@ -1,112 +1,119 @@
 from __future__ import annotations
 import pandas as pd
 import numpy as np
-import builtins
 from dataclasses import dataclass
 import random
 from tqdm import tqdm
-import warnings
 
-warnings.filterwarnings(
-    "ignore",
-    category=FutureWarning,
-    # You can use a regex to match the specific warning message
-    message="The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. *"
-)
-
-def gini_impurity(y: pd.Series) -> float:
-    proportions = y.value_counts(normalize=True)
+def gini_impurity(y: np.ndarray) -> float:
+    """Optimized gini using numpy arrays instead of pandas"""
+    if len(y) == 0:
+        return 0
+    _, counts = np.unique(y, return_counts=True)
+    proportions = counts / len(y)
     return 1 - np.sum(proportions**2)
 
 
-def gini_gain(y: pd.Series, left_mask: pd.Series, right_mask: pd.Series) -> float:
-    if left_mask.sum() == 0 or right_mask.sum() == 0:
+def gini_gain(y: np.ndarray, left_mask: np.ndarray, right_mask: np.ndarray) -> float:
+    """Optimized gini gain using numpy arrays"""
+    left_count = np.sum(left_mask)
+    right_count = np.sum(right_mask)
+    
+    if left_count == 0 or right_count == 0:
         return -np.inf
+    
+    total_count = len(y)
     left_impurity = gini_impurity(y[left_mask])
     right_impurity = gini_impurity(y[right_mask])
-    weighted_impurity = (
-        left_mask.sum() * left_impurity + right_mask.sum() * right_impurity
-    ) / len(y)
-
+    
+    weighted_impurity = (left_count * left_impurity + right_count * right_impurity) / total_count
     return gini_impurity(y) - weighted_impurity
 
 
-def get_splits_continuous(col: pd.Series, num_splits: int = 5):
-    unique_vals = np.sort(col.unique())
-
+def get_splits_continuous(col: np.ndarray, num_splits: int = 5):
+    """Optimized continuous splits using numpy"""
+    unique_vals = np.unique(col[~np.isnan(col)])  # Remove NaNs first
+    
     if len(unique_vals) <= 1:
-        return  # nothing to split
-
+        return
+    
     if len(unique_vals) <= num_splits:
-        # Use all midpoints between adjacent values
         thresholds = (unique_vals[:-1] + unique_vals[1:]) / 2
     else:
-        # Use quantile-based thresholds
-        percentiles = np.linspace(0, 100, num_splits + 2)[1:-1]  # drop 0% and 100%
-        thresholds = np.unique(np.percentile(col, percentiles))
-
+        percentiles = np.linspace(0, 100, num_splits + 2)[1:-1]
+        thresholds = np.unique(np.percentile(unique_vals, percentiles))
+    
     for t in thresholds:
         left_mask = col <= t
         yield float(t), left_mask, ~left_mask
 
 
-def get_random_splits_categorical(
-        col: pd.Series, y: pd.Series, num_random: int = 5
-    ):
-    unique_vals = list(col.dropna().unique())
+def get_random_splits_categorical(col: np.ndarray, num_random: int = 5):
+    """Optimized categorical splits using numpy"""
+    # Remove NaNs and get unique values
+    mask = ~pd.isna(col)
+    if not mask.any():
+        return
+        
+    unique_vals = np.unique(col[mask])
     n = len(unique_vals)
-
+    
     if n <= 1:
         return
-
-    # Try num_random random non-trivial subsets
+    
     for _ in range(num_random):
-        k = random.randint(1, n - 1)  # avoid empty or full set
-        subset = set(random.sample(unique_vals, k))
-        left_mask = col.isin(subset)
+        k = random.randint(1, n - 1)
+        subset = set(np.random.choice(unique_vals, k, replace=False))
+        left_mask = np.isin(col, list(subset))
         right_mask = ~left_mask
-
-        if left_mask.sum() == 0 or right_mask.sum() == 0:
+        
+        if not left_mask.any() or not right_mask.any():
             continue
-
+            
         yield subset, left_mask, right_mask
 
 
-def gini_best_splits(X: pd.DataFrame, y: pd.Series, features_to_explore: list | None = None):
+def gini_best_splits(X: np.ndarray, y: np.ndarray, feature_names: list, features_to_explore: list | None = None):
+    """Optimized best splits using numpy arrays"""
     best_splits = [(None, None, -np.inf)]
-    if features_to_explore is not None:
-        features_to_explore = X.columns
-    for col in features_to_explore:
-        x_col = X[col]
+    
+    if features_to_explore is None:
+        features_to_explore = list(range(len(feature_names)))
+    else:
+        # Convert feature names to indices
+        features_to_explore = [feature_names.index(f) for f in features_to_explore if f in feature_names]
+    
+    for col_idx in features_to_explore:
+        x_col = X[:, col_idx]
         best_gain = -np.inf
         best_condition = None
         
-        # 1. Handle regular splits
-        if pd.api.types.is_numeric_dtype(x_col):
+        # Handle regular splits
+        if np.issubdtype(x_col.dtype, np.number):
             splitter = get_splits_continuous(x_col)
         else:
-            splitter = get_random_splits_categorical(x_col, y)
-
+            splitter = get_random_splits_categorical(x_col)
+        
         for condition, left_mask, right_mask in splitter:
             gain = gini_gain(y, left_mask, right_mask)
             if gain > best_gain:
                 best_gain = gain
                 best_condition = condition
-
-        # 2. Handle null split explicitly
-        null_mask = x_col.isnull()
+        
+        # Handle null split
+        null_mask = pd.isna(x_col)
         non_null_mask = ~null_mask
         if null_mask.any() and non_null_mask.any():
             null_gain = gini_gain(y, null_mask, non_null_mask)
             if null_gain > best_gain:
                 best_gain = null_gain
                 best_condition = "__NULL__"
-
+        
         if best_gain == best_splits[0][2]:
-            best_splits.append((col, best_condition, best_gain))
+            best_splits.append((feature_names[col_idx], best_condition, best_gain))
         elif best_gain > best_splits[0][2]:
-            best_splits = [(col, best_condition, best_gain)]
-
+            best_splits = [(feature_names[col_idx], best_condition, best_gain)]
+    
     return best_splits
 
 
@@ -118,20 +125,20 @@ class CartNode:
     condition: float | set | str | None
     probabilities: dict[str, float]
 
-    def split(self, X: pd.DataFrame) -> tuple[tuple[CartNode, pd.Series], tuple[CartNode, pd.Series]]:
-        match type(self.condition):
-            case builtins.set:
-                left_mask = X[self.split_column].isin(self.condition)
-            case builtins.float:
-                left_mask = X[self.split_column] <= self.condition
-            case builtins.str:
-                left_mask = X[self.split_column].isnull()
-            case _:
-                raise ValueError("Condition is not valid!")
-        return (
-            (self.left, left_mask),
-            (self.right, ~left_mask)
-        )
+    def split(self, X: np.ndarray, col_idx: int) -> tuple[np.ndarray, np.ndarray]:
+        """Optimized split using numpy arrays"""
+        x_col = X[:, col_idx]
+        
+        if isinstance(self.condition, set):
+            left_mask = np.isin(x_col, list(self.condition))
+        elif isinstance(self.condition, float):
+            left_mask = x_col <= self.condition
+        elif isinstance(self.condition, str):
+            left_mask = pd.isna(x_col)
+        else:
+            raise ValueError("Condition is not valid!")
+            
+        return left_mask, ~left_mask
 
 
 class RandCart:
@@ -144,52 +151,72 @@ class RandCart:
             min_samples_split: int = 5,
             use_progress_bar: bool = False
         ):
-        self.X_train = X_train
-        self.y_train = y_train
+        # Convert to numpy arrays for faster computation
+        self.X_train_np = X_train.values
+        self.y_train_np = y_train.values
+        self.feature_names = list(X_train.columns)
+        self.class_names = [str(c) for c in y_train.unique()]
+        
         self.max_features_to_explore = min(max_features_to_explore, len(X_train.columns)//2)
         self.max_depth = max_depth
         self.min_samples_split = min_samples_split
-        self.root = CartNode(None, None, None, None, self.get_probs_as_dict(y_train))
+        self.root = CartNode(None, None, None, None, self.get_probs_as_dict(y_train.values))
         self.use_progress_bar = use_progress_bar
 
-    def get_probs_as_dict(self, y: pd.Series):
-        return {
-            str(v): sum(y == v)/len(y)
-            for v in self.y_train.unique()
-        }
+    def get_probs_as_dict(self, y: np.ndarray):
+        """Optimized probability calculation using numpy"""
+        if len(y) == 0:
+            return {name: 0.0 for name in self.class_names}
+        
+        unique_vals, counts = np.unique(y, return_counts=True)
+        prob_dict = {str(val): count/len(y) for val, count in zip(unique_vals, counts)}
+        
+        # Fill in missing classes with 0 probability
+        for class_name in self.class_names:
+            if class_name not in prob_dict:
+                prob_dict[class_name] = 0.0
+                
+        return prob_dict
 
     def predict(self, X: pd.DataFrame):
-        assert list(X.columns) == list(self.X_train.columns), "Inference data does not have the same columns as train data"
-        X.index = range(len(X))
-        y_cols = [str(c) for c in self.y_train.unique()]
-        nodes_to_visit = [(self.root, X)]
-
-        predictions = pd.DataFrame(columns=y_cols)
-
-        while len(nodes_to_visit) > 0:
-            node, X_temp = nodes_to_visit.pop()
-            assert node is not None, "Arrived at a non-existing node"
-
-            if not node.split_column:
-                predictions = pd.concat([
-                    predictions,
-                    pd.DataFrame(
-                        index=X_temp.index,
-                        data=[{v: node.probabilities.get(str(v), 0) for v in y_cols}]
-                    )
-                ])
-            else:
-                (left_node, left_mask), (right_node, right_mask) = node.split(X_temp)
-                nodes_to_visit.extend([
-                    (left_node, X_temp[left_mask]),
-                    (right_node, X_temp[right_mask])
-                ])
+        """Optimized prediction using numpy arrays"""
+        assert list(X.columns) == self.feature_names, "Inference data does not have the same columns as train data"
         
-        return predictions.sort_index()
+        X_np = X.values
+        n_samples = len(X)
+        n_classes = len(self.class_names)
+        
+        # Pre-allocate result array
+        predictions = np.zeros((n_samples, n_classes))
+        sample_indices = np.arange(n_samples)
+        
+        nodes_to_visit = [(self.root, sample_indices)]
+        
+        while nodes_to_visit:
+            node, indices = nodes_to_visit.pop()
+            
+            if node.split_column is None:
+                # Leaf node - assign probabilities
+                for i, class_name in enumerate(self.class_names):
+                    predictions[indices, i] = node.probabilities.get(class_name, 0)
+            else:
+                # Split node
+                col_idx = self.feature_names.index(node.split_column)
+                left_mask, right_mask = node.split(X_np[indices], col_idx)
+                
+                left_indices = indices[left_mask]
+                right_indices = indices[right_mask]
+                
+                if len(left_indices) > 0:
+                    nodes_to_visit.append((node.left, left_indices))
+                if len(right_indices) > 0:
+                    nodes_to_visit.append((node.right, right_indices))
+        
+        return pd.DataFrame(predictions, columns=self.class_names, index=X.index)
 
     def fit(self):
         if self.use_progress_bar:
-            max_nodes = 2 ** (self.max_depth + 1) - 1  # Conservative full tree estimate
+            max_nodes = 2 ** (self.max_depth + 1) - 1
             pbar = tqdm(total=max_nodes, desc="Training RandCart")
 
         def should_stop(y, best_gain, depth):
@@ -200,38 +227,45 @@ class RandCart:
                 depth >= self.max_depth
             )
         
-        def expand_tree(node: CartNode, index: pd.Index, depth: int):
-            X_temp = self.X_train.loc[index]
-            random_features = np.random.choice(X_temp.columns, self.max_features_to_explore)
-
-            y_temp = self.y_train.loc[index]
-
-            best_splits = gini_best_splits(X_temp, y_temp, random_features)
+        def expand_tree(node: CartNode, indices: np.ndarray, depth: int):
+            X_temp = self.X_train_np[indices]
+            y_temp = self.y_train_np[indices]
+            
+            # Randomly select features to explore
+            n_features_to_try = min(self.max_features_to_explore, len(self.feature_names))
+            random_feature_indices = np.random.choice(len(self.feature_names), n_features_to_try, replace=False)
+            random_features = [self.feature_names[i] for i in random_feature_indices]
+            
+            best_splits = gini_best_splits(X_temp, y_temp, self.feature_names, random_features)
 
             if should_stop(y_temp, best_splits[0][2], depth):
                 if self.use_progress_bar:
                     pbar.update(2 ** (self.max_depth + 1 - depth) - 1)
                 return
 
-            chosen_split = best_splits[random.randint(0, len(best_splits)-1)]
+            chosen_split = random.choice(best_splits)
             if self.use_progress_bar:
                 pbar.update(1)
 
             node.split_column = chosen_split[0]
             node.condition = chosen_split[1]
 
-            (_, left_mask), (_, right_mask) = node.split(X_temp)
+            col_idx = self.feature_names.index(node.split_column)
+            left_mask, right_mask = node.split(X_temp, col_idx)
 
+            left_indices = indices[left_mask]
             left_y = y_temp[left_mask]
             node.left = CartNode(None, None, None, None, self.get_probs_as_dict(left_y))
-            expand_tree(node.left, left_y.index, depth+1)
+            expand_tree(node.left, left_indices, depth+1)
 
+            right_indices = indices[right_mask]
             right_y = y_temp[right_mask]
             node.right = CartNode(None, None, None, None, self.get_probs_as_dict(right_y))
-            expand_tree(node.right, right_y.index, depth+1)
+            expand_tree(node.right, right_indices, depth+1)
 
-
-        expand_tree(self.root, self.y_train.index, 0)
+        initial_indices = np.arange(len(self.y_train_np))
+        expand_tree(self.root, initial_indices, 0)
+        
         if self.use_progress_bar:
             pbar.close()
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,6 @@
 from sklearn.model_selection import train_test_split
 from sklearn.datasets import fetch_openml
 from sklearn.metrics import accuracy_score, confusion_matrix
-
 from random_forest import predict_rf, random_forest
 
 def get_accuracy(y_test, preds):
@@ -26,7 +25,7 @@ bootstrap_size = 1000
 min_samples_split = 5
 
 print("Generating the random forest...")
-tree_ls = random_forest(X_train, y_train, n_estimators, max_features, max_depth, bootstrap_size, min_samples_split, )
+tree_ls = random_forest(X_train, y_train, n_estimators, max_features, max_depth, bootstrap_size, min_samples_split)
 
 print("Predicting the testing set...")
 y_pred = predict_rf(tree_ls, X_test)

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@ from sklearn.datasets import fetch_openml
 from sklearn.metrics import accuracy_score, confusion_matrix
 from random_forest import predict_rf, random_forest
 
+
 def get_accuracy(y_test, preds):
     hits = 0
     for i in range(len(y_test)):
@@ -25,16 +26,24 @@ bootstrap_size = 1000
 min_samples_split = 5
 
 print("Generating the random forest...")
-tree_ls = random_forest(X_train, y_train, n_estimators, max_features, max_depth, bootstrap_size, min_samples_split)
+tree_ls = random_forest(
+    X_train,
+    y_train,
+    n_estimators,
+    max_features,
+    max_depth,
+    bootstrap_size,
+    min_samples_split,
+)
 
 print("Predicting the testing set...")
 y_pred = predict_rf(tree_ls, X_test)
 
 accuracy = accuracy_score(y_test, y_pred)
-print(f'Accuracy: {accuracy * 100:.2f}%')
+print(f"Accuracy: {accuracy * 100:.2f}%")
 
-#conf_matrix = confusion_matrix(y_test, y_pred)
-#print(conf_matrix)
+# conf_matrix = confusion_matrix(y_test, y_pred)
+# print(conf_matrix)
 
 
 ###### Random forest from sklearn ######
@@ -43,7 +52,7 @@ from sklearn.preprocessing import LabelEncoder
 from sklearn.ensemble import RandomForestClassifier
 
 # Encode categorical features
-categorical_cols = X.select_dtypes(include=['object']).columns
+categorical_cols = X.select_dtypes(include=["object"]).columns
 X_encoded = X.copy()
 label_encoders = {}
 
@@ -58,7 +67,16 @@ X_enc_train, X_enc_test, y_train, y_test = train_test_split(
     X_encoded, y, test_size=0.2, random_state=42, stratify=y
 )
 
-clf = RandomForestClassifier(criterion="gini", random_state=42, max_depth=max_depth, n_estimators=n_estimators, min_samples_split=min_samples_split, bootstrap=True, max_features=max_features, max_samples=bootstrap_size)
+clf = RandomForestClassifier(
+    criterion="gini",
+    random_state=42,
+    max_depth=max_depth,
+    n_estimators=n_estimators,
+    min_samples_split=min_samples_split,
+    bootstrap=True,
+    max_features=max_features,
+    max_samples=bootstrap_size,
+)
 clf.fit(X_enc_train, y_train)
 
 # Predict and evaluate
@@ -66,4 +84,4 @@ y_pred = clf.predict(X_enc_test)
 accuracy = accuracy_score(y_test, y_pred)
 conf_matrix = confusion_matrix(y_test, y_pred)
 
-print(f'Accuracy sklearn: {accuracy * 100:.2f}%')
+print(f"Accuracy sklearn: {accuracy * 100:.2f}%")

--- a/src/random_forest.py
+++ b/src/random_forest.py
@@ -2,31 +2,37 @@ import numpy as np
 
 from class_reg_decision_tree import RandCart
 
+
 def predict_rf(tree_ls, X_test):
     # One row per each entry in the X_test
     predictions = [[] for _ in range(len(X_test))]
     for tree in tree_ls:
         tree_pred = tree.predict(X_test)
-        
+
         for entry in range(len(tree_pred)):
             predictions[entry].append(tree_pred.iloc[entry].idxmax())
-    
+
     # Get the max prediction of each tree for each element in X_test
     preds = []
     for row_pred in predictions:
-        counter = [[x,row_pred.count(x)] for x in set(row_pred)]
+        counter = [[x, row_pred.count(x)] for x in set(row_pred)]
         counter_sorted = sorted(counter, key=lambda item: -item[1])
         preds.append(counter_sorted[0][0])
 
     return preds
 
+
 def draw_bootstrap(X_train, y_train, bootstrap_size):
     bootstrap_indices = np.random.randint(len(X_train), size=bootstrap_size)
-    oob_indices = np.array([i for i in range(len(X_train)) if i not in bootstrap_indices])
+    oob_indices = np.array(
+        [i for i in range(len(X_train)) if i not in bootstrap_indices]
+    )
 
     print(f"Bootstrap size: {len(bootstrap_indices)}")
     print(f"OOB size: {len(oob_indices)}")
-    print(f"Duplicated elements: {(len(oob_indices)+len(bootstrap_indices)-len(X_train))}")
+    print(
+        f"Duplicated elements: {(len(oob_indices)+len(bootstrap_indices)-len(X_train))}"
+    )
 
     X_bootstrap = X_train.iloc[bootstrap_indices]
     y_bootstrap = y_train.iloc[bootstrap_indices]
@@ -34,6 +40,7 @@ def draw_bootstrap(X_train, y_train, bootstrap_size):
     y_oob = y_train.iloc[oob_indices]
 
     return X_bootstrap, y_bootstrap, X_oob, y_oob
+
 
 def oob_score(tree, X_test, y_test):
     mis_label = 0
@@ -43,13 +50,26 @@ def oob_score(tree, X_test, y_test):
             mis_label += 1
     return mis_label / len(X_test)
 
-def random_forest(X_train, y_train, n_estimators, max_features, max_depth, bootstrap_size, min_samples_split):
+
+def random_forest(
+    X_train,
+    y_train,
+    n_estimators,
+    max_features,
+    max_depth,
+    bootstrap_size,
+    min_samples_split,
+):
     tree_ls = list()
     oob_ls = list()
     for i in range(n_estimators):
         print(f"Creating tree #{i}")
-        X_bootstrap, y_bootstrap, X_oob, y_oob = draw_bootstrap(X_train, y_train, bootstrap_size)
-        tree = RandCart(X_bootstrap, y_bootstrap, max_features, max_depth, min_samples_split, True)
+        X_bootstrap, y_bootstrap, X_oob, y_oob = draw_bootstrap(
+            X_train, y_train, bootstrap_size
+        )
+        tree = RandCart(
+            X_bootstrap, y_bootstrap, max_features, max_depth, min_samples_split, True
+        )
         tree.fit()
         tree_ls.append(tree)
         oob_error = oob_score(tree, X_oob, y_oob)

--- a/src/random_forest.py
+++ b/src/random_forest.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import numpy as np
 
 from class_reg_decision_tree import RandCart


### PR DESCRIPTION
This PR refactors the decision tree logic to use Numpy instead of Pandas. This change helps speeding up the code, which will be useful to create random forests with more trees to compare with scikit-learn.

This is an example of the speedup obtained when running the code with 39 trees.

Before:
```
python src/main.py  235,30s user 2,14s system 99% cpu 3:59,53 total
```

After:
```
python src/main.py  23,21s user 0,30s system 98% cpu 23,888 total
```

In addition, I run the black formatter tool to the code. This will make the git diff less noisy in the future.

> [!WARNING]
> The refactor was done with Claude, so we should double-check that the status quo is preserved. All the tests passed when testing it and we get a similar result than scikit-learn for the letter dataset